### PR TITLE
Bugfix: no universal libs in Release and Profile configs

### DIFF
--- a/ios/build.sh
+++ b/ios/build.sh
@@ -201,7 +201,7 @@ function lipo_ia32_and_armv7() {
 
     if [ "$WEBRTC_PROFILE" = true ] ; then
         lipo -create $BUILD/libWebRTC-$WEBRTC_REVISION-sim-Profile.a $BUILD/libWebRTC-$WEBRTC_REVISION-ios-Profile.a -output $BUILD/libWebRTC-$WEBRTC_REVISION-armv7-ia32-Profile.a
-        rm $BUILD/libWebRTC-$WEBRTC_REVISION-armv7-ia32-Profile.a
+        rm $WEBRTC/libWebRTC-LATEST-Universal-Profile.a
         ln -s $BUILD/libWebRTC-$WEBRTC_REVISION-armv7-ia32-Profile.a $WEBRTC/libWebRTC-LATEST-Universal-Profile.a
         echo "The libWebRTC-LATEST-Universal-Profile.a in this same directory, is revision " > $WEBRTC/libWebRTC-LATEST-Universal-Profile.a.version.txt
         echo $WEBRTC_REVISION >> $WEBRTC/libWebRTC-LATEST-Universal-Profile.a.version.txt
@@ -209,7 +209,7 @@ function lipo_ia32_and_armv7() {
 
     if [ "$WEBRTC_RELEASE" = true ] ; then
         lipo -create $BUILD/libWebRTC-$WEBRTC_REVISION-sim-Release.a $BUILD/libWebRTC-$WEBRTC_REVISION-ios-Release.a -output $BUILD/libWebRTC-$WEBRTC_REVISION-armv7-ia32-Release.a
-        rm $BUILD/libWebRTC-$WEBRTC_REVISION-armv7-ia32-Release.a
+        rm $WEBRTC/libWebRTC-LATEST-Universal-Release.a
         ln -s $BUILD/libWebRTC-$WEBRTC_REVISION-armv7-ia32-Release.a $WEBRTC/libWebRTC-LATEST-Universal-Release.a
         echo "The libWebRTC-LATEST-Universal-Release.a in this same directory, is revision " > $WEBRTC/libWebRTC-LATEST-Universal-Release.a.version.txt
         echo $WEBRTC_REVISION >> $WEBRTC/libWebRTC-LATEST-Universal-Release.a.version.txt


### PR DESCRIPTION
If a Release or Profile config is built the universal lib is immediately deleted and the `LATEST` symlink will be broken.
