### PR TITLE
(android) build_apprtc and build_debug_apprtc can take a revision number

### DIFF
--- a/README.md
+++ b/README.md
@@ -51,6 +51,17 @@ build_debug_apprtc
 
 ```
 
+You can build a particular [revision](https://code.google.com/p/webrtc/source/list)
+```shell
+
+# Build apprtc
+build_apprtc 6783
+
+# Build in debug mode
+build_debug_apprtc 6783
+
+```
+
 When the scripts are done you can find the .jar and .so file in $WEBRTC_HOME under "libjingle\_peerconnection\_builds".
 
 ###iOS -- [Guide here](http://tech.pristine.io/build-ios-apprtc/)

--- a/android/build.sh
+++ b/android/build.sh
@@ -204,7 +204,7 @@ get_webrtc_revision() {
 # Updates webrtc and builds apprtc
 build_apprtc() {
     pull_depot_tools &&
-    pull_webrtc && 
+    pull_webrtc $1 && 
     prepare_gyp_defines &&
     prepare_build && 
     execute_build
@@ -213,7 +213,7 @@ build_apprtc() {
 # Updates webrtc and builds apprtc in debug
 build_debug_apprtc() {
     pull_depot_tools &&
-    pull_webrtc && 
+    pull_webrtc $1 && 
     prepare_gyp_defines &&
     prepare_build && 
     execute_debug_build


### PR DESCRIPTION
This makes it easier to select which revision to build. For example:

``` python
build_apprtc 6783 # builds r6783
build_apprtc # still builds the latest revision
```

Inspired by https://code.google.com/p/webrtc/issues/detail?id=3622#c12
