### PR TITLE
remove --nohooks so the chromium pull will be executed the first time

### DIFF
--- a/android/build.sh
+++ b/android/build.sh
@@ -92,11 +92,11 @@ pull_webrtc() {
 	if [ -z $1 ]
     then
         echo "gclient sync with newest"
-        gclient sync --nohooks
+        gclient sync 
     else
     	trunkA="trunk@"
         echo "gclient sync with r$1"
-        gclient sync -r $trunkA$1 --nohooks
+        gclient sync -r $trunkA$1 
     fi
 
     # Navigate back


### PR DESCRIPTION
With the new git pull for the Chromium code, we need the hooks to run the very first time to get all the source code
