### PR TITLE
Update iOS build script to support new src directory

### DIFF
--- a/ios/build.sh
+++ b/ios/build.sh
@@ -149,7 +149,6 @@ function sync() {
 # Convenience function to copy the headers by creating a symbolic link to the headers directory deep within webrtc src
 function copy_headers() {
     create_directory_if_not_found "$BUILD"
-    create_directory_if_not_found "$WEBRTC/headers"
     ln -s $WEBRTC/src/talk/app/webrtc/objc/public/ $WEBRTC/headers
 }
 


### PR DESCRIPTION
The main update here is due to the change in the root directory but also included are a few minor typo fixes and what I believe is a fix for the failed symbolic link to headers. Thanks for sharing your great work!
