### PR TITLE
Run 'strip' when making Release builds to remove un-needed symbols an…

### DIFF
--- a/ios/build.sh
+++ b/ios/build.sh
@@ -32,6 +32,11 @@ function exec_libtool() {
   libtool -static -v -o $@
 }
 
+function exec_strip() {
+  echo "Running strip"
+  strip -S -X $@
+}
+
 function exec_ninja() {
   echo "Running ninja"
   ninja -C $1 $WEBRTC_TARGET
@@ -201,6 +206,7 @@ function build_webrtc_mac() {
 
     if [ "$WEBRTC_RELEASE" = true ] ; then
         exec_ninja "out_ios_x86/Release/"
+        exec_strip $WEBRTC/src/out_ios_x86/Release-iphoneos/*.a
         exec_libtool "$BUILD/libWebRTC-$WEBRTC_REVISION-mac-x86_64-Release.a" $WEBRTC/src/out_ios_x86/Release/*.a
     fi
 }
@@ -227,6 +233,7 @@ function build_apprtc_sim() {
 
     if [ "$WEBRTC_RELEASE" = true ] ; then
         exec_ninja "out_ios_x86/Release-iphonesimulator/"
+        exec_strip $WEBRTC/src/out_ios_x86/Release-iphonesimulator/*.a
         exec_libtool "$BUILD/libWebRTC-$WEBRTC_REVISION-ios-x86-Release.a" $WEBRTC/src/out_ios_x86/Release-iphonesimulator/*.a
     fi
 }
@@ -253,6 +260,7 @@ function build_apprtc() {
 
     if [ "$WEBRTC_RELEASE" = true ] ; then
         exec_ninja "out_ios_armeabi_v7a/Release-iphoneos/"
+        exec_strip $WEBRTC/src/out_ios_armeabi_v7a/Release-iphoneos/*.a
         exec_libtool "$BUILD/libWebRTC-$WEBRTC_REVISION-ios-armeabi_v7a-Release.a" $WEBRTC/src/out_ios_armeabi_v7a/Release-iphoneos/*.a
     fi
 }
@@ -280,6 +288,7 @@ function build_apprtc_arm64() {
 
     if [ "$WEBRTC_RELEASE" = true ] ; then
         exec_ninja "out_ios_arm64_v8a/Release-iphoneos/"
+        exec_strip $WEBRTC/src/out_ios_arm64_v8a/Release-iphoneos/*.a
         exec_libtool "$BUILD/libWebRTC-$WEBRTC_REVISION-ios-arm64_v8a-Release.a" $WEBRTC/src/out_ios_arm64_v8a/Release-iphoneos/*.a
     fi
 }


### PR DESCRIPTION
…d significantly reduce the size of resulting static library.

This branch also includes some miscellaneous script cleanup
