### PR TITLE
Don't fail script if folder already exists

### DIFF
--- a/android/build.sh
+++ b/android/build.sh
@@ -243,7 +243,7 @@ execute_build() {
 
         #cp -pr "$SOURCE_DIR"/* "$TARGET_DIR"
         cd $TARGET_DIR
-        mkdir res # make resources directory
+        mkdir -p res # make resources directory
 
         zip -r "$TARGET_DIR/$REVISION_NUM.zip" .
         cd $WORKING_DIR


### PR DESCRIPTION
Caused build failure when run in Jenkins:

```
+ cd /var/lib/jenkins/jobs/build-webrtc/workspace/android/webrtc/libjingle_peerconnection_builds/Debug
+ mkdir res
mkdir: cannot create directory ‘res’: File exists
Build step 'Execute shell' marked build as failure
Finished: FAILURE
```