### PR TITLE
Fix correct path to libjingle_peerconnection_so.so

### DIFF
--- a/android/build.sh
+++ b/android/build.sh
@@ -234,7 +234,7 @@ execute_build() {
 
         cp -p "$SOURCE_DIR/libjingle_peerconnection.jar" "$TARGET_DIR/libs/" 
 
-        $STRIP -o $ARCH_JNI/libjingle_peerconnection_so.so $WEBRTC_ROOT/src/$ARCH_OUT/$BUILD_TYPE/libjingle_peerconnection_so.so -s
+        $STRIP -o $ARCH_JNI/libjingle_peerconnection_so.so $WEBRTC_ROOT/src/$ARCH_OUT/$BUILD_TYPE/lib/libjingle_peerconnection_so.so -s
 
         #cp -pr "$SOURCE_DIR"/* "$TARGET_DIR"
         cd $TARGET_DIR


### PR DESCRIPTION
Otherwise the error is 
`/vagrant/webrtc/src/chromium/src/third_party/android_tools/ndk/toolchains/arm-linux-androideabi-4.9/prebuilt/linux-x86_64/bin/arm-linux-androideabi-strip: '/vagrant/webrtc/src/out_android_armeabi_v7a/Debug/libjingle_peerconnection_so.so': No such file`