### PR TITLE
Use nfs for vagrant to speed up and fix ld issues

### DIFF
--- a/android/Vagrantfile
+++ b/android/Vagrantfile
@@ -12,5 +12,8 @@ Vagrant.configure(VAGRANTFILE_API_VERSION) do |config|
     vb.cpus = 2
   end
 
+  config.vm.network "private_network", ip: "192.168.50.4"
+  config.vm.synced_folder ".", "/vagrant", type: :nfs
+
   config.vm.provision "shell", path: "provision.sh"
 end


### PR DESCRIPTION
Without nfs mount build script issues `ld` errors on hard linking (tested on Mac OS Yosemite). Also, it speeds up filesystem overall work.