### PR TITLE
Build for jni/java by default

### DIFF
--- a/android/build.sh
+++ b/android/build.sh
@@ -108,7 +108,7 @@ pull_webrtc() {
 
 # Prepare our build
 function wrbase() {
-    export GYP_DEFINES="OS=android host_os=linux libjingle_java=1 build_with_libjingle=1 build_with_chromium=0 enable_tracing=1 enable_android_opensl=1"
+    export GYP_DEFINES="OS=android host_os=linux libjingle_java=1 build_with_libjingle=1 build_with_chromium=0 enable_tracing=1 enable_android_opensl=0"
     export GYP_GENERATORS="ninja"
 }
 


### PR DESCRIPTION
By default webrtc members suggest using jni/java vs. OpenSL, see details [here](https://code.google.com/p/webrtc/issues/detail?id=4293)