### PR TITLE
Minor fix to use the project as a local development pod

### DIFF
--- a/ios/build.sh
+++ b/ios/build.sh
@@ -503,7 +503,7 @@ function create_archive_of_static_libraries() {
     echo "revision $WEBRTC_REVISION $1 build" > "libjingle_peerconnection/libjingle_peerconnection_revision_build.txt"
     
     # add headers
-    ln -sfv "$WEBRTC/src/talk/app/webrtc/objc/public/" "libjingle_peerconnection/Headers"
+    cp -fvR "$WEBRTC/src/talk/app/webrtc/objc/public/" "libjingle_peerconnection/Headers"
 
     # Compress artifact
     tar --use-compress-prog=pbzip2 -cvLf "libWebRTC.tar.bz2" *

--- a/ios/build.sh
+++ b/ios/build.sh
@@ -510,6 +510,8 @@ function create_archive_of_static_libraries() {
 
     echo Go back to working directory
     cd $WORKING_DIR
+	
+	ln -sfv "$BUILD/archives/$WEBRTC_REVISION/$1" "$BUILD/LATEST"
 }
 
 # Grabs the current version build based on what is


### PR DESCRIPTION
This fix allows the project to be used as a development pod.

- The header files must be copied instead of linked. If they are linked CocoaPods does not create the project correctly (the header files are missing).
- Adding a link to the last build result.

After building the project, it can be used in the Podfile like this:

    pod 'libjingle_peerconnection', :path => '../webrtc-build-scripts/ios/webrtc/libjingle_peerconnection_builds/LATEST/libjingle_peerconnection.podspec'
 