### PR TITLE
Updated podspec to include VideoToolbox due to most recent update

### DIFF
--- a/ios/libjingle_peerconnection.podspec
+++ b/ios/libjingle_peerconnection.podspec
@@ -26,8 +26,8 @@ Pod::Spec.new do |s|
   s.ios.deployment_target = '7.0'
   s.osx.deployment_target = '10.8'
   s.source_files =  'libjingle_peerconnection/Headers/*.h'
-  s.osx.framework = 'AVFoundation', 'AudioToolbox', 'CoreGraphics', 'CoreMedia', 'GLKit', 'QTKit', 'CoreAudio', 'CoreVideo'
-  s.ios.framework = 'AVFoundation', 'AudioToolbox', 'CoreGraphics', 'CoreMedia', 'GLKit', 'UIKit'
+  s.osx.framework = 'AVFoundation', 'AudioToolbox', 'CoreGraphics', 'CoreMedia', 'GLKit', 'QTKit', 'CoreAudio', 'CoreVideo', 'VideoToolbox'
+  s.ios.framework = 'AVFoundation', 'AudioToolbox', 'CoreGraphics', 'CoreMedia', 'GLKit', 'UIKit', 'VideoToolbox'
   s.libraries = 'c', 'sqlite3', 'stdc++'
   s.requires_arc = true
   s.xcconfig  =  { 'LIBRARY_SEARCH_PATHS' => '"$(PODS_ROOT)/libjingle_peerconnection"',


### PR DESCRIPTION
Got a long linker error relating to H624 something or other. Most likely relating to some update in webrtc.  Adding VideoToolbox to the required frameworks fixed it.