### PR TITLE
added .gitattributes to handle eol

### DIFF
--- a/.gitattributes
+++ b/.gitattributes
@@ -1,0 +1,3 @@
+# default to text file with UNIX style
+* text=auto eol=lf
+


### PR DESCRIPTION
this should fix first part of issue #115, by keeping Unix style end-of-line for all text files, even on Windows.