### PR TITLE
Guard get_revision_number against quoted replies.

### DIFF
--- a/ios/build.sh
+++ b/ios/build.sh
@@ -147,11 +147,11 @@ function get_revision_number() {
     DIR=`pwd`
     cd "$WEBRTC/src"
 
-    REVISION_NUMBER=`git log -1 | grep 'Cr-Commit-Position: refs/heads/master@{#' | egrep -o "[0-9]+}" | tr -d '}'`
+    REVISION_NUMBER=`git log -1 | grep 'Cr-Commit-Position: refs/heads/master@{#' | grep -v '>' | egrep -o "[0-9]+}" | tr -d '}'`
 
     if [ -z "$REVISION_NUMBER" ]
     then
-        REVISION_NUMBER=`git log -1 | grep 'Cr-Commit-Position: refs/branch-heads/' | egrep -o "[0-9]+" | awk 'NR%2{printf $0"-";next;}1'`
+        REVISION_NUMBER=`git log -1 | grep 'Cr-Commit-Position: refs/branch-heads/' | grep -v '>' | egrep -o "[0-9]+" | awk 'NR%2{printf $0"-";next;}1'`
     fi
 
     if [ -z "$REVISION_NUMBER" ]


### PR DESCRIPTION
In cases where the git log has a quoted reply from another commit
the get_revision_number function gets confused returning multiple
revision numbers. This causes downstream failures in the build script,
particularly the linking step.

An example commit from upstream webrtc that can cause this.
https://chromium.googlesource.com/external/webrtc/+/a67696b3cde98163ee38de8313ee9eddb73c662e

Error example:
```
Running ninja
ninja: Entering directory `out_ios_arm64_v8a/Debug-iphoneos/'
ninja: no work to do.
Running libtool
error: /Applications/Xcode.app/Contents/Developer/Toolchains/XcodeDefault.xctoolchain/usr/bin/libtool: can't open file: 10041 (No such file or directory)
error: /Applications/Xcode.app/Contents/Developer/Toolchains/XcodeDefault.xctoolchain/usr/bin/libtool: can't open file: 10112-ios-arm64_v8a-Debug.a (No such file or directory)
```
