### PR TITLE
Added libfield_trial dependency when creating dummy shared_library, F…

### DIFF
--- a/ios/insert_two_lines_after_text.py
+++ b/ios/insert_two_lines_after_text.py
@@ -8,6 +8,7 @@ FIND = """    ['OS=="ios" or (OS=="mac" and target_arch!="ia32" and mac_sdk>="10
 APPEND = """        { 'target_name': 'libWebRTC_objc', # Injected target using github.com/pristineio/webrtc-build-scripts
           'type': 'shared_library', # We are creating a dummy shared_library so all the dependencies are built as static libraries. i think this is a bug
           'dependencies': [
+            '<(webrtc_root)/system_wrappers/system_wrappers.gyp:field_trial_default',
             '../talk/libjingle.gyp:libjingle_peerconnection_objc',
           ],
           'sources': [


### PR DESCRIPTION
…ixes issue #138 

Commit c1aeaf0dc37d96f31c92f893f4e30e7a5f7cc2b7 from webrtc added libfield_trial dependency to target 'apprtc_common' as static_library but webrtc_build_scripts use a different target that didn't compile the library.