### PR TITLE
fix ninja: error: unknown target libWebRTC_objc

### DIFF
--- a/ios/insert_two_lines_after_text.py
+++ b/ios/insert_two_lines_after_text.py
@@ -4,7 +4,7 @@ import sys, ast, json
 
 FILE = sys.argv[1]
 
-FIND = """    ['OS=="ios" or (OS=="mac" and target_arch!="ia32" and mac_sdk>="10.8")', {"""
+FIND = """    ['OS=="ios" or (OS=="mac" and target_arch!="ia32")', {"""
 APPEND = """        { 'target_name': 'libWebRTC_objc', # Injected target using github.com/pristineio/webrtc-build-scripts
           'type': 'shared_library', # We are creating a dummy shared_library so all the dependencies are built as static libraries. i think this is a bug
           'dependencies': [


### PR DESCRIPTION
[https://github.com/pristineio/webrtc-build-scripts/blob/06c047a01f835c09618172cb823a9a01e4b31d37/ios/insert_two_lines_after_text.py#L7](https://github.com/pristineio/webrtc-build-scripts/blob/06c047a01f835c09618172cb823a9a01e4b31d37/ios/insert_two_lines_after_text.py#L7)

The string FIND can not be found in $WEBRTC/src/webrtc/webrtc_examples.gyp