### PR TITLE
Fixes #163. QTKit dependency removed from OSX deps

### DIFF
--- a/ios/libjingle_peerconnection.podspec
+++ b/ios/libjingle_peerconnection.podspec
@@ -26,7 +26,7 @@ Pod::Spec.new do |s|
   s.ios.deployment_target = '7.0'
   s.osx.deployment_target = '10.8'
   s.source_files =  'libjingle_peerconnection/Headers/*.h'
-  s.osx.framework = 'AVFoundation', 'AudioToolbox', 'CoreGraphics', 'CoreMedia', 'GLKit', 'QTKit', 'CoreAudio', 'CoreVideo', 'VideoToolbox'
+  s.osx.framework = 'AVFoundation', 'AudioToolbox', 'CoreGraphics', 'CoreMedia', 'GLKit', 'CoreAudio', 'CoreVideo', 'VideoToolbox'
   s.ios.framework = 'AVFoundation', 'AudioToolbox', 'CoreGraphics', 'CoreMedia', 'GLKit', 'UIKit', 'VideoToolbox'
   s.libraries = 'c', 'sqlite3', 'stdc++'
   s.requires_arc = true


### PR DESCRIPTION
Related WebRTC bug: https://bugs.chromium.org/p/webrtc/issues/detail?id=3968