### PR TITLE
Support GN build system for android

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,4 +1,4 @@
-##PSA - WebRTC builds have moved to using GN instead of GYP. We currently don't have the capacity to update these. Feel free to fork and update them
+##PSA - WebRTC builds have moved to using GN instead of GYP. Android build script is adapted, but iOS script is still break. Feel free to fork and update them.
 
 ##WebRTC Build Scripts
 


### PR DESCRIPTION
Chromium is moving build system from GYP to GN and break the webrtc
build script, this commit fix the break of Android build.
Tested on Ubuntu and WSL.