### PR TITLE
Unify expected strings for arm architecture

### DIFF
--- a/android/build.sh
+++ b/android/build.sh
@@ -1,5 +1,5 @@
 # !/bin/bash
-# Copyright Pristine Inc 
+# Copyright Pristine Inc
 # Author: Rahul Behera <rahul@pristine.io>
 # Author: Aaron Alaniz <aaron@pristine.io>
 # Author: Arik Yaacob   <arik@pristine.io>
@@ -206,11 +206,11 @@ execute_build() {
     then
         ARCH="x64"
         STRIP="$ANDROID_TOOLCHAINS/x86_64-4.9/prebuilt/linux-x86_64/bin/x86_64-linux-android-strip"
-    elif [ "$WEBRTC_ARCH" = "armeabi-v7a" ] ;
+    elif [ "$WEBRTC_ARCH" = "armv7" ] ;
     then
         ARCH="arm"
         STRIP="$ANDROID_TOOLCHAINS/arm-linux-androideabi-4.9/prebuilt/linux-x86_64/bin/arm-linux-androideabi-strip"
-    elif [ "$WEBRTC_ARCH" = "arm64-v8a" ] ;
+    elif [ "$WEBRTC_ARCH" = "armv8" ] ;
     then
         ARCH="arm64"
         STRIP="$ANDROID_TOOLCHAINS/aarch64-linux-android-4.9/prebuilt/linux-x86_64/bin/aarch64-linux-android-strip"
@@ -226,21 +226,21 @@ execute_build() {
     fi
 
     ARCH_OUT="out_android_${ARCH}"
-    
+
     echo Generate projects using GN
     gn gen "$ARCH_OUT/$BUILD_TYPE" --args="$DEBUG_ARG symbol_level=1 target_os=\"android\" target_cpu=\"${ARCH}\""
     #gclient runhooks
-    
+
     REVISION_NUM=`get_webrtc_revision`
     echo "Build ${WEBRTC_TARGET} in $BUILD_TYPE (arch: ${WEBRTC_ARCH})"
     exec_ninja "$ARCH_OUT/$BUILD_TYPE"
-    
+
     # Verify the build actually worked
     if [ $? -eq 0 ]; then
         SOURCE_DIR="$WEBRTC_ROOT/src/$ARCH_OUT/$BUILD_TYPE"
         TARGET_DIR="$BUILD/$BUILD_TYPE"
         create_directory_if_not_found "$TARGET_DIR"
-        
+
         echo "Copy JAR File"
         create_directory_if_not_found "$TARGET_DIR/libs/"
         create_directory_if_not_found "$TARGET_DIR/jni/"
@@ -249,14 +249,14 @@ execute_build() {
         create_directory_if_not_found "$ARCH_JNI"
 
         # Copy the jar
-        cp -p "$SOURCE_DIR/lib.java/webrtc/api/libjingle_peerconnection_java.jar" "$TARGET_DIR/libs/libjingle_peerconnection.jar" 
+        cp -p "$SOURCE_DIR/lib.java/webrtc/api/libjingle_peerconnection_java.jar" "$TARGET_DIR/libs/libjingle_peerconnection.jar"
 
         # Strip the build only if its release
         if [ "$WEBRTC_DEBUG" = "true" ] ;
         then
             cp -p "$WEBRTC_ROOT/src/$ARCH_OUT/$BUILD_TYPE/libjingle_peerconnection_so.so" "$ARCH_JNI/libjingle_peerconnection_so.so"
         else
-            "$STRIP" -o "$ARCH_JNI/libjingle_peerconnection_so.so" "$WEBRTC_ROOT/src/$ARCH_OUT/$BUILD_TYPE/libjingle_peerconnection_so.so" -s    
+            "$STRIP" -o "$ARCH_JNI/libjingle_peerconnection_so.so" "$WEBRTC_ROOT/src/$ARCH_OUT/$BUILD_TYPE/libjingle_peerconnection_so.so" -s
         fi
 
         cd "$TARGET_DIR"
@@ -267,7 +267,7 @@ execute_build() {
         cd "$WORKING_DIR"
         echo "$BUILD_TYPE build for apprtc complete for revision $REVISION_NUM"
     else
-        
+
         echo "$BUILD_TYPE build for apprtc failed for revision $REVISION_NUM"
         #exit 1
     fi
@@ -301,11 +301,11 @@ get_webrtc() {
 
 # Updates webrtc and builds apprtc
 build_apprtc() {
-    export WEBRTC_ARCH=armeabi-v7a
+    export WEBRTC_ARCH=armv7
     prepare_gyp_defines &&
     execute_build
 
-    export WEBRTC_ARCH=arm64-v8a
+    export WEBRTC_ARCH=armv8
     prepare_gyp_defines &&
     execute_build
 


### PR DESCRIPTION
In the documentation as well as in other parts of build.sh "armv7" and "armv8" are used to decide the build architecture.

Currently there's no problem if build_apprtc() is used because it overwrites WEBRTC_ARCH. But if you only want to build one architecture and follow the readme, it says that 

export WEBRTC_ARCH=armv7
or
export WEBRTC_ARCH=armv8

should be used. In that case, the if inside execute_build() will fail because is looking for "armeabi-v7a" and "arm64-v8a"